### PR TITLE
Replace deprecated numpy aliases for builtin types

### DIFF
--- a/src/plugins/pwscf.py
+++ b/src/plugins/pwscf.py
@@ -24,7 +24,7 @@ def qe_value_map(value):
             return '.true.'
         else:
             return '.false.'
-    elif isinstance(value, (float, numpy.float)) or isinstance(value, (int, numpy.int)):
+    elif isinstance(value, (float, numpy.floating, int, numpy.integer)):
         return str(value)
     elif isinstance(value, str):
         return "'{}'".format(value)


### PR DESCRIPTION
This PR replaces numpy aliases (`numpy.int` and `numpy.float`) in `pwscf.py`, which have been deprecated since numpy 1.20:
https://numpy.org/devdocs/release/1.20.0-notes.html#using-the-aliases-of-builtin-types-like-np-int-is-deprecated